### PR TITLE
Basic led driver for 'tpm2net' protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,13 @@ if(ENABLE_OSX)
 	set(CMAKE_EXE_LINKER_FLAGS "-framework CoreGraphics")
 endif()
 
+
+# Boost Lib for UDP
+find_package(Boost COMPONENTS system REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+set(CMAKE_EXE_LINKER_FLAGS "-lboost_system")
+
+
 configure_file(bin/install_hyperion.sh ${LIBRARY_OUTPUT_PATH} @ONLY)
 configure_file(config/hyperion.config.json ${LIBRARY_OUTPUT_PATH} @ONLY)
 configure_file(config/hyperion_x86.config.json ${LIBRARY_OUTPUT_PATH} @ONLY)

--- a/config/hyperion.config.json
+++ b/config/hyperion.config.json
@@ -5,9 +5,12 @@
 	/// Device configuration contains the following fields: 
 	/// * 'name'       : The user friendly name of the device (only used for display purposes)
 	/// * 'type'       : The type of the device or leds (known types for now are 'ws2801', 'ldp8806',
-	///                  'lpd6803', 'sedu', 'adalight', 'lightpack', 'philipshue', 'test' and 'none')
+	///                  'lpd6803', 'sedu', 'adalight', 'lightpack', 'philipshue', 'test', 'none', 
+			     and 'tpm2net')
 	/// * 'output'     : The output specification depends on selected device. This can for example be the
-	///                  device specifier, device serial number, or the output file name
+	///                  device specifier, device serial number, the output file name,
+			     or the target IP address for tpm2net (one or mutiple, space separated)
+	/// * 'port'	   : tpm2net target port
 	/// * 'rate'       : The baudrate of the output to the device
 	/// * 'colorOrder' : The order of the color bytes ('rgb', 'rbg', 'bgr', etc.).
 	/// Specific of Philips Hue: 
@@ -19,6 +22,7 @@
 		"name"       : "MyPi",
 		"type"       : "ws2801",
 		"output"     : "/dev/spidev0.0",
+ 		//"port"       : 65506, // TPM2.net
 		"rate"       : 250000,
 		"colorOrder" : "rgb"
 	},

--- a/libsrc/leddevice/CMakeLists.txt
+++ b/libsrc/leddevice/CMakeLists.txt
@@ -37,6 +37,7 @@ SET(Leddevice_HEADERS
 		${CURRENT_SOURCE_DIR}/LedDeviceFadeCandy.h
 		${CURRENT_SOURCE_DIR}/LedDeviceHyperionUsbasp.h
 		${CURRENT_SOURCE_DIR}/LedDeviceTpm2.h
+		${CURRENT_SOURCE_DIR}/LedDeviceTpm2net.h
 		${CURRENT_SOURCE_DIR}/LedDeviceAtmo.h
 )
 
@@ -60,6 +61,7 @@ SET(Leddevice_SOURCES
 		${CURRENT_SOURCE_DIR}/LedDeviceHyperionUsbasp.cpp
 		${CURRENT_SOURCE_DIR}/LedDevicePhilipsHue.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceTpm2.cpp
+                ${CURRENT_SOURCE_DIR}/LedDeviceTpm2net.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceAtmo.cpp
 )
 

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -34,6 +34,7 @@
 #include "LedDeviceHyperionUsbasp.h"
 #include "LedDevicePhilipsHue.h"
 #include "LedDeviceTpm2.h"
+#include "LedDeviceTpm2net.h"
 #include "LedDeviceAtmo.h"
 #include "LedDeviceAdalightApa102.h"
 
@@ -260,6 +261,14 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		deviceTpm2->open();
 		device = deviceTpm2;
 	}
+        else if (type == "tpm2net")
+        {
+                const std::string output = deviceConfig.get("output", "127.0.0.1").asString();
+                const uint16_t port     = deviceConfig.get("port", 65506).asInt();
+                LedDeviceTpm2net * deviceTpm2net = new LedDeviceTpm2net(output, port);
+                device = deviceTpm2net;
+        }
+
 	else if (type == "atmo")
 	{
 		const std::string output = deviceConfig["output"].asString();

--- a/libsrc/leddevice/LedDeviceTpm2net.cpp
+++ b/libsrc/leddevice/LedDeviceTpm2net.cpp
@@ -1,0 +1,97 @@
+// STL includes
+#include <cstring>
+#include <cstdio>
+#include <iostream>
+
+// Boost Lib include for UDP mgt
+#include "boost/asio.hpp"
+
+ using namespace boost::asio;
+
+// Local-Hyperion includes
+#include "LedDeviceTpm2net.h"
+
+
+LedDeviceTpm2net::LedDeviceTpm2net(const std::string & output, uint16_t port) :
+		_port(port)
+{
+	// split output by space
+	std::stringstream ss(output+' ');
+    std::string item;
+    while(std::getline(ss, item, ' ')) 
+    {
+        _output_ip.push_back(item);
+				
+    }
+    
+}
+
+LedDeviceTpm2net::~LedDeviceTpm2net()
+{
+	// empty
+}
+
+
+int LedDeviceTpm2net::write(const std::vector<ColorRgb> & ledValues)
+{
+
+	/* LED BUFFER */
+		if (_ledBuffer.size() == 0)
+		{
+				_ledBuffer.resize(7 + 3*ledValues.size());
+				_ledBuffer[0] = 0x9c; // block-start byte TPM.NET
+				_ledBuffer[1] = 0xDA;
+				_ledBuffer[2] = ((3 * ledValues.size()) >> 8) & 0xFF; // frame size high byte
+				_ledBuffer[3] = (3 * ledValues.size()) & 0xFF; // frame size low byte
+				_ledBuffer[4] = 1; // packets number
+				_ledBuffer[5] = 1; // Number of packets 
+				_ledBuffer.back() = 0x36; // block-end byte
+		}
+
+		// write data
+		memcpy(6 + _ledBuffer.data(), ledValues.data() /*Max 1,490 bytes*/, ledValues.size() * 3);
+	/* EOF LED BUFFER */
+
+	/* UDP */
+	io_service io_service;
+	ip::udp::socket socket(io_service);
+	ip::udp::endpoint remote_endpoint;
+	boost::system::error_code err;
+
+	// Broadcast mode (slower)
+	/*
+		socket.open(ip::udp::v4());
+		 socket.set_option(ip::udp::socket::reuse_address(true));
+		socket.set_option(socket_base::broadcast(true));
+
+		ip::udp::endpoint senderEndpoint(ip::address_v4::broadcast(), 65506);            
+
+		socket.send_to(buffer(_ledBuffer.data(), _ledBuffer.size()), senderEndpoint, 0, err);
+		socket.close();
+		
+	*/
+	
+	//Loop thru all dest
+	for ( int i = 0; i < _output_ip.size(); ++i) {
+		 
+		/* Simple send */
+		socket.open(ip::udp::v4());
+		remote_endpoint = ip::udp::endpoint(ip::address::from_string(_output_ip[i]), _port);
+		socket.send_to(buffer(_ledBuffer.data(), _ledBuffer.size()), remote_endpoint, 0, err);
+		//std::cout << _output_ip[i] << std::endl;
+		socket.close();
+		/* Eof simple send */
+	}
+	
+	/* eof UDP */
+	
+	return 0;
+}
+
+int LedDeviceTpm2net::switchOff()
+{
+	/* LED BUFFER */
+	memset(6 + _ledBuffer.data(), 0, _ledBuffer.size() - 5);
+	/* EOF LED BUFFER */
+	return 0;
+}

--- a/libsrc/leddevice/LedDeviceTpm2net.h
+++ b/libsrc/leddevice/LedDeviceTpm2net.h
@@ -1,0 +1,46 @@
+#pragma once
+//  cmake -DENABLE_DISPMANX=OFF -DENABLE_SPIDEV=OFF -DENABLE_X11=OFF -DENABLE_V4L2=OFF -DENABLE_PROTOBUF=OFF .
+
+// STL includes0
+#include <fstream>
+#include <string>
+#include "boost/asio.hpp"
+
+// Leddevice includes
+#include <leddevice/LedDevice.h>
+
+///
+class LedDeviceTpm2net : public LedDevice
+{
+public:
+	///
+	/// Constructs the test-device, which opens an output stream to the file
+	///
+	LedDeviceTpm2net(const std::string& output, uint16_t port);
+
+	virtual ~LedDeviceTpm2net();
+
+	///
+	/// Writes the given led-color values to the output stream
+	///
+	/// @param ledValues The color-value per led
+	///
+	/// @return Zero on success else negative
+	///
+	virtual int write(const std::vector<ColorRgb> & ledValues);
+
+	/// Switch the leds off
+	virtual int switchOff();
+
+private:
+		
+	/// The buffer containing the packed RGB values
+	std::vector<uint8_t> _ledBuffer;
+	
+	/// The host of the master brick
+	std::vector<std::string> _output_ip;
+
+	/// The port of the master brick
+	const uint16_t _port;
+
+};

--- a/src/hyperiond/CMakeLists.txt
+++ b/src/hyperiond/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(hyperiond
 		effectengine
 		jsonserver
 		boblightserver
+		boost_system
 )
 
 if (ENABLE_DISPMANX)


### PR DESCRIPTION
Basic led driver for 'tpm2net' protocol. Requires -lboost_system. Works great with ESP-12 & esplightnode.